### PR TITLE
Removendo referência de projeto inexistente (LibHomeFinalProj)

### DIFF
--- a/HomeLib.sln
+++ b/HomeLib.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HomeLib", "HomeLib\HomeLib.csproj", "{13BE8AA1-8E0A-45DF-97DE-DF3F3FD8FACB}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LibHomeFinalProj", "..\LibHomeFinalProj\LibHomeFinalProj\LibHomeFinalProj.csproj", "{C6555380-B6AE-43CE-BB47-BDBB61F4FB40}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{13BE8AA1-8E0A-45DF-97DE-DF3F3FD8FACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{13BE8AA1-8E0A-45DF-97DE-DF3F3FD8FACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{13BE8AA1-8E0A-45DF-97DE-DF3F3FD8FACB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C6555380-B6AE-43CE-BB47-BDBB61F4FB40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C6555380-B6AE-43CE-BB47-BDBB61F4FB40}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C6555380-B6AE-43CE-BB47-BDBB61F4FB40}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C6555380-B6AE-43CE-BB47-BDBB61F4FB40}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#Principal
Projeto continha uma referência quebrada à uma biblioteca inexistente no repositório.